### PR TITLE
apt-get install libjudy-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requirements
 ------------
 
   * libjudy
-	  * Debian-based: `apt-get install libjudy`
+	  * Debian-based: `apt-get install libjudy-dev`
 	  * OSX: `brew install judy`
 
 API


### PR DESCRIPTION
`apt-get install libjudy-dev` instead of `apt-get install libjudy`
